### PR TITLE
Add functionality to control the display of the close button in the modal

### DIFF
--- a/src/components/sq-modal/sq-modal.component.html
+++ b/src/components/sq-modal/sq-modal.component.html
@@ -21,7 +21,7 @@
         <ng-container *ngIf="headerTemplate">
           <ng-container *ngTemplateOutlet="headerTemplate"></ng-container>
         </ng-container>
-        <button type="button" class="close button-close" aria-label="Close" (click)="modalClose.emit()">
+        <button *ngIf="buttonClose" type="button" class="close button-close" aria-label="Close" (click)="modalClose.emit()">
           <i class="fa-solid fa-xmark fa-lg"></i>
         </button>
       </div>

--- a/src/components/sq-modal/sq-modal.component.ts
+++ b/src/components/sq-modal/sq-modal.component.ts
@@ -19,11 +19,11 @@ import { Subscription } from 'rxjs'
 
 /**
  * Represents a modal component with customizable options and event handling.
- * 
+ *
  * Look the link about the component in original framework and the appearance
  *
  * @see {@link https://css.squidit.com.br/components/modal}
- * 
+ *
  * @example
  * <sq-modal [open]="isModalOpen" (modalClose)="onModalClose()">
  *   <ng-template #headerModal>
@@ -76,6 +76,11 @@ export class SqModalComponent implements OnChanges, OnDestroy {
    * Determines whether clicking outside the modal closes it. Options: 'static' (no close), 'true' (close).
    */
   @Input() backdrop = 'static'
+
+  /**
+   * Determines whether to display the close button.
+   */
+  @Input() buttonClose = true
 
   /**
    * Event emitted when the modal is closed.

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squidit/ngx-css",
-  "version": "1.2.25",
+  "version": "1.2.26",
   "peerDependencies": {
     "@angular/common": ">=15.0.0",
     "@angular/core": ">=15.0.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic control over the visibility of the close button in modal dialogs through a new `buttonClose` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->