### PR TITLE
bugfix/SQ-62222

### DIFF
--- a/src/helpers/date.helper.ts
+++ b/src/helpers/date.helper.ts
@@ -78,7 +78,7 @@ export class DateHelper {
    * @returns Date offset by the specified timezone.
    */
   timezoneDate(date: Date, timezone?: string): Date {
-    return new Date(date.toLocaleString('en-US', { timeZone: timezone }))
+    return new Date(date.toLocaleString('en-US', { timeZone: timezone || undefined }))
   }
 
   /**
@@ -89,7 +89,7 @@ export class DateHelper {
    * @returns A Date object representing the first moment of the day at 00:00:00.
    */
   startOfDay(date: Date, timezone?: string): Date {
-    const tzDate = new Date(date.getFullYear(), date.getMonth(), date.getDate()).toLocaleString('en-US', {timeZone: timezone})
+    const tzDate = new Date(date.getFullYear(), date.getMonth(), date.getDate()).toLocaleString('en-US', {timeZone: timezone || undefined})
     return new Date(tzDate)
   }
 


### PR DESCRIPTION
Card: [SQ-62222](https://duopana.myjetbrains.com/youtrack/issue/SQ-62222) [FRONT] - NGX-CSS - String vazia não funciona como timezone em algumas funções

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved timezone handling in date-related functions for enhanced flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->