### PR TITLE
feat: Add support for generic label templates in sq-input component

### DIFF
--- a/src/components/sq-input-date/sq-input-date.component.html
+++ b/src/components/sq-input-date/sq-input-date.component.html
@@ -1,13 +1,16 @@
 <div class="wrapper-all-inside-input {{ customClass }}">
   <label
     class="display-flex"
-    *ngIf="label?.length || tooltipMessage"
+    *ngIf="label?.length || tooltipMessage || labelTemplate"
     [ngClass]="{
       readonly: readonly
     }"
     [for]="id"
   >
-    <div *ngIf="label" [ngStyle]="{ 'color': labelColor }" [innerHtml]="label | universalSafe"></div>
+    <div *ngIf="label && !labelTemplate" [ngStyle]="{ 'color': labelColor }" [innerHtml]="label | universalSafe"></div>
+    <div *ngIf="labelTemplate">
+      <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
+    </div>
     <sq-tooltip
       *ngIf="tooltipMessage"
       class="ml-1"

--- a/src/components/sq-input-date/sq-input-date.component.ts
+++ b/src/components/sq-input-date/sq-input-date.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, Optional } from '@angular/core'
+import { Component, ContentChild, ElementRef, Input, Optional, TemplateRef } from '@angular/core'
 import { TranslateService } from '@ngx-translate/core'
 import { ValidatorHelper } from '../../helpers/validator.helper'
 import { SqInputComponent } from '../sq-input/sq-input.component'
@@ -54,6 +54,12 @@ export class SqInputDateComponent extends SqInputComponent {
   public override get value(): any {
     return this._value.toISOString().split('T')[0]
   }
+
+  /**
+   * Reference to a label template.
+   */
+  @ContentChild('labelTemplate')
+  override labelTemplate: TemplateRef<HTMLElement> | null = null
 
   /**
    * Constructs a new instance of SqInputDateComponent.

--- a/src/components/sq-input-mask/sq-input-mask.component.html
+++ b/src/components/sq-input-mask/sq-input-mask.component.html
@@ -1,13 +1,16 @@
 <div class="wrapper-all-inside-input {{ customClass }}">
   <label
     class="display-flex"
-    *ngIf="label?.length || tooltipMessage"
+    *ngIf="label?.length || tooltipMessage || labelTemplate"
     [ngClass]="{
       readonly: readonly
     }"
     [for]="id"
   >
-    <div *ngIf="label" [ngStyle]="{ 'color': labelColor }" [innerHtml]="label | universalSafe"></div>
+    <div *ngIf="label && !labelTemplate" [ngStyle]="{ 'color': labelColor }" [innerHtml]="label | universalSafe"></div>
+    <div *ngIf="labelTemplate">
+      <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
+    </div>
     <sq-tooltip
       *ngIf="tooltipMessage"
       class="ml-1"

--- a/src/components/sq-input-mask/sq-input-mask.component.ts
+++ b/src/components/sq-input-mask/sq-input-mask.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, Optional } from "@angular/core"
+import { Component, ContentChild, ElementRef, Input, Optional, TemplateRef } from "@angular/core"
 import { ValidatorHelper } from '../../helpers/validator.helper'
 import { TranslateService } from "@ngx-translate/core"
 import { SqInputComponent } from "../sq-input/sq-input.component"
@@ -74,6 +74,12 @@ export class SqInputMaskComponent extends SqInputComponent {
    * Defines the maximum value that can be accepted as input.
    */
   @Input() maxValue?: number
+
+  /**
+   * Reference to a label template.
+   */
+  @ContentChild('labelTemplate')
+  override labelTemplate: TemplateRef<HTMLElement> | null = null
 
   /**
    * Reference to the native element.

--- a/src/components/sq-input-money/sq-input-money.component.html
+++ b/src/components/sq-input-money/sq-input-money.component.html
@@ -36,12 +36,16 @@
   (keyPressUp)="keyPressUp.emit($event)"
   (keyPressDown)="keyPressDown.emit($event)"
 >
+  <ng-container *ngIf="labelTemplateOverwrite">
+    <ng-template #labelTemplate>
+      <ng-container *ngTemplateOutlet="labelTemplateOverwrite"></ng-container>
+    </ng-template>
+  </ng-container>
   <ng-container *ngIf="prefix">
     <ng-template #leftLabel>
       {{ prefix }}
     </ng-template>
   </ng-container>
-
   <ng-container *ngIf="rightLabelOverwrite">
     <ng-template #rightLabel>
       <ng-container *ngTemplateOutlet="rightLabelOverwrite"></ng-container>

--- a/src/components/sq-input-money/sq-input-money.component.ts
+++ b/src/components/sq-input-money/sq-input-money.component.ts
@@ -89,6 +89,12 @@ export class SqInputMoneyComponent extends SqInputComponent implements OnChanges
   rightLabelOverwrite: TemplateRef<HTMLElement> | null = null
 
   /**
+   * Reference to a label template.
+   */
+  @ContentChild('labelTemplate')
+  labelTemplateOverwrite: TemplateRef<HTMLElement> | null = null
+
+  /**
    * Constructs a new instance of SqInputMaskComponent.
    * @param validatorHelper - The ValidatorHelper service for input validation.
    * @param element - Reference to the native element.

--- a/src/components/sq-input-number/sq-input-number.component.html
+++ b/src/components/sq-input-number/sq-input-number.component.html
@@ -37,6 +37,11 @@
   (keyPressUp)="keyPressUp.emit($event)"
   (keyPressDown)="keyPressDown.emit($event)"
 >
+<ng-container *ngIf="labelTemplateOverwrite">
+  <ng-template #labelTemplate>
+    <ng-container *ngTemplateOutlet="labelTemplateOverwrite"></ng-container>
+  </ng-template>
+</ng-container>
   <ng-container *ngIf="leftLabelOverwrite">
     <ng-template #leftLabel>
       <ng-container *ngTemplateOutlet="leftLabelOverwrite"></ng-container>

--- a/src/components/sq-input-number/sq-input-number.component.ts
+++ b/src/components/sq-input-number/sq-input-number.component.ts
@@ -90,6 +90,12 @@ export class SqInputNumberComponent extends SqInputComponent {
   rightLabelOverwrite: TemplateRef<HTMLElement> | null = null
 
   /**
+   * Reference to a label template.
+   */
+  @ContentChild('labelTemplate')
+  labelTemplateOverwrite: TemplateRef<HTMLElement> | null = null
+
+  /**
    * Reference to the native element.
    */
   override nativeElement: ElementRef

--- a/src/components/sq-input-range/sq-input-range.component.html
+++ b/src/components/sq-input-range/sq-input-range.component.html
@@ -3,14 +3,17 @@
 }">
   <label
     class="display-flex"
-    *ngIf="label?.length"
+    *ngIf="label?.length || labelTemplate"
     [ngClass]="{
       readonly: readonly
     }"
     [for]="id"
   >
-    <div *ngIf="label?.length" [ngStyle]="{ 'color': labelColor }" [innerHtml]="label | universalSafe"></div>
+    <div *ngIf="label?.length && !labelTemplate" [ngStyle]="{ 'color': labelColor }" [innerHtml]="label | universalSafe"></div>
   </label>
+  <div *ngIf="labelTemplate">
+    <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
+  </div>
   <div
     class="p-0 wrapper-input wrapper-input-squid"
     [ngClass]="{

--- a/src/components/sq-input-range/sq-input-range.component.ts
+++ b/src/components/sq-input-range/sq-input-range.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, Component, ElementRef, EventEmitter, Input, OnChanges, Optional, Output, SimpleChanges, ViewChild } from '@angular/core'
+import { AfterContentInit, Component, ContentChild, ElementRef, EventEmitter, Input, OnChanges, Optional, Output, SimpleChanges, TemplateRef, ViewChild } from '@angular/core'
 import { TranslateService } from '@ngx-translate/core'
 import { ValidatorHelper } from '../../helpers/validator.helper'
 import { sleep } from '../../helpers/sleep.helper'
@@ -132,6 +132,13 @@ export class SqInputRangeComponent implements AfterContentInit, OnChanges {
    * A reference to the 'input' element in the component template.
    */
   @ViewChild('input') input!: ElementRef
+
+  /**
+   * Reference to a label template.
+   */
+  @ContentChild('labelTemplate')
+  labelTemplate: TemplateRef<HTMLElement> | null = null
+
 
   /**
    * The error message associated with the input.

--- a/src/components/sq-select/sq-select.component.html
+++ b/src/components/sq-select/sq-select.component.html
@@ -1,13 +1,16 @@
 <div class="wrapper-all-inside-input {{ customClass }}">
   <label
     class="display-flex"
-    *ngIf="label?.length || tooltipMessage"
+    *ngIf="label?.length || tooltipMessage || labelTemplate"
     [ngClass]="{
       readonly: readonly
     }"
     [for]="id"
   >
-    <div *ngIf="label" [ngStyle]="{ 'color': labelColor }" [innerHtml]="label | universalSafe"></div>
+    <div *ngIf="label && !labelTemplate" [ngStyle]="{ 'color': labelColor }" [innerHtml]="label | universalSafe"></div>
+    <div *ngIf="labelTemplate">
+      <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
+    </div>
     <sq-tooltip
       *ngIf="tooltipMessage"
       class="ml-1"

--- a/src/components/sq-select/sq-select.component.ts
+++ b/src/components/sq-select/sq-select.component.ts
@@ -186,6 +186,12 @@ export class SqSelectComponent {
   rightLabel: TemplateRef<HTMLElement> | null = null
 
   /**
+   * Reference to a right-aligned label template.
+   */
+  @ContentChild('labelTemplate')
+  labelTemplate: TemplateRef<HTMLElement> | null = null
+
+  /**
    * The error state of the select input.
    */
   error: boolean | string = false

--- a/src/components/sq-selector/sq-selector.component.html
+++ b/src/components/sq-selector/sq-selector.component.html
@@ -18,9 +18,6 @@
       <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
     </div>
   </label>
-  <div *ngIf="labelTemplate">
-    <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
-  </div>
   <input
     [id]="id"
     [name]="name"

--- a/src/components/sq-selector/sq-selector.component.html
+++ b/src/components/sq-selector/sq-selector.component.html
@@ -8,11 +8,19 @@
     block: block,
   }"
 >
-  <label [for]="id" *ngIf="leftLabel" [ngClass]="{'label-max-width': hideInput}">
+  <label [for]="id" *ngIf="leftLabel && !labelTemplate" [ngClass]="{'label-max-width': hideInput}">
     <ng-container
       *ngTemplateOutlet="leftLabel; context: context"
     ></ng-container>
   </label>
+  <label for="id" *ngIf="labelTemplate" [ngClass]="{'label-max-width': hideInput}">
+    <div *ngIf="labelTemplate">
+      <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
+    </div>
+  </label>
+  <div *ngIf="labelTemplate">
+    <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
+  </div>
   <input
     [id]="id"
     [name]="name"

--- a/src/components/sq-selector/sq-selector.component.ts
+++ b/src/components/sq-selector/sq-selector.component.ts
@@ -206,6 +206,12 @@ export class SqSelectorComponent implements OnChanges {
   leftLabel: TemplateRef<HTMLElement> | null = null
 
   /**
+   * Reference to a right-aligned label template.
+   */
+  @ContentChild('labelTemplate')
+  labelTemplate: TemplateRef<HTMLElement> | null = null
+
+  /**
    * Indicates whether the selector input is currently checked.
    */
   thisChecked = false

--- a/src/components/sq-textarea/sq-textarea.component.html
+++ b/src/components/sq-textarea/sq-textarea.component.html
@@ -1,13 +1,16 @@
 <div class="wrapper-all-inside-input {{ customClass }}">
   <label
     class="display-flex"
-    *ngIf="label?.length || tooltipMessage"
+    *ngIf="label?.length || tooltipMessage || labelTemplate"
     [ngClass]="{
       readonly: readonly
     }"
     [for]="id"
   >
-    <div *ngIf="label" [ngStyle]="{ 'color': labelColor }" [innerHtml]="label | universalSafe"></div>
+    <div *ngIf="label && !labelTemplate" [ngStyle]="{ 'color': labelColor }" [innerHtml]="label | universalSafe"></div>
+    <div *ngIf="labelTemplate">
+      <ng-container *ngTemplateOutlet="labelTemplate"></ng-container>
+    </div>
     <sq-tooltip
       *ngIf="tooltipMessage"
       class="ml-1"

--- a/src/components/sq-textarea/sq-textarea.component.ts
+++ b/src/components/sq-textarea/sq-textarea.component.ts
@@ -184,6 +184,12 @@ export class SqTextAreaComponent {
   rightLabel: TemplateRef<HTMLElement> | null = null
 
   /**
+   * Reference to a label template.
+   */
+  @ContentChild('labelTemplate')
+  labelTemplate: TemplateRef<HTMLElement> | null = null
+
+  /**
    * Represents the error state of the textarea.
    */
   error: boolean | string = false

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squidit/ngx-css",
-  "version": "1.3.39",
+  "version": "1.3.40",
   "peerDependencies": {
     "@angular/common": ">=15.0.0",
     "@angular/core": ">=15.0.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added customizable label templates to various components (`sq-input-date`, `sq-input-mask`, `sq-input-range`, `sq-select`, `sq-selector`, `sq-input-money`, `sq-input-number`, `sq-textarea`).
  - Components now support conditional rendering of custom labels via `labelTemplate`.

- **Improvements**
  - Enhanced flexibility for label display, allowing for more personalized user interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->