### PR TITLE
SQ-65829 [FRONT] padronizar sq-select-multi-tags e sq-select-search no ngx-css

### DIFF
--- a/src/components/sq-select-multi-tags/sq-select-multi-tags.component.html
+++ b/src/components/sq-select-multi-tags/sq-select-multi-tags.component.html
@@ -49,7 +49,8 @@
       <div
         class="input-fake-content"
         [ngClass]="{
-          disabled: disabled
+          disabled: disabled,
+          readonly: readonly
         }"
         (click)="doDropDownAction()"
       >
@@ -63,7 +64,7 @@
           </span>
         </div>
         <span *ngIf="value?.length" class="badge">{{ value!.length }}</span>
-        <i *ngIf="!loading && !readonly" class="icon-down fas fa-chevron-down"></i>
+        <i *ngIf="!loading" class="icon-down fas fa-chevron-down"></i>
       </div>
       <div
         *ngIf="!loading && !disabled && !readonly && !isMaxTags && renderOptionsList"

--- a/src/components/sq-select-multi-tags/sq-select-multi-tags.component.scss
+++ b/src/components/sq-select-multi-tags/sq-select-multi-tags.component.scss
@@ -52,6 +52,12 @@
       position: absolute;
       font-size: 0.86rem;
     }
+    &.readonly {
+      cursor: not-allowed;
+      pointer-events: none;
+      background-color: var(--color_border_input);
+      border-color: var(--color_border_input_disabled);
+    }
   }
 
   .loading-wrapper {

--- a/src/components/sq-select-search/sq-select-search.component.html
+++ b/src/components/sq-select-search/sq-select-search.component.html
@@ -47,7 +47,8 @@
     <div
       class="input-fake-content"
       [ngClass]="{
-        disabled: disabled
+        disabled: disabled,
+        readonly: readonly
       }"
       (click)="doDropDownAction()"
     >
@@ -63,7 +64,7 @@
       <i *ngIf="!loading" class="icon-down fas fa-chevron-down"></i>
     </div>
     <div
-      *ngIf="!disabled && !loading && renderOptionsList"
+      *ngIf="!disabled && !loading && renderOptionsList && !readonly"
       class="input-window scrollbar"
       id="sq-select-search-scroll"
       [ngClass]="{

--- a/src/components/sq-select-search/sq-select-search.component.scss
+++ b/src/components/sq-select-search/sq-select-search.component.scss
@@ -38,6 +38,12 @@
       position: absolute;
       font-size: 0.86rem;
     }
+    &.readonly {
+      cursor: not-allowed;
+      pointer-events: none;
+      background-color: var(--color_border_input);
+      border-color: var(--color_border_input_disabled);
+    }
   }
   .loading-wrapper {
     position: absolute;

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squidit/ngx-css",
-  "version": "1.3.40",
+  "version": "1.3.48",
   "peerDependencies": {
     "@angular/common": ">=15.0.0",
     "@angular/core": ">=15.0.0",


### PR DESCRIPTION
https://duopana.myjetbrains.com/youtrack/issue/SQ-65829/FRONT-padronizar-sq-select-multi-tags-e-sq-select-search-no-ngx-css

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `readonly` state for the multi-tag selection and search components, enhancing visual feedback for users.
	- Updated UI elements to indicate when components are in a read-only mode, improving usability and accessibility.

- **Bug Fixes**
	- Adjusted icon visibility logic to ensure clarity in user interaction, particularly when components are read-only.

- **Style**
	- Added new `.readonly` CSS class to visually indicate the non-interactive state of components, enhancing user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->