### PR TITLE
feat: add bodyPadding input to SqOverlayComponent for customizable padding

### DIFF
--- a/src/components/sq-overlay/sq-overlay.component.html
+++ b/src/components/sq-overlay/sq-overlay.component.html
@@ -32,7 +32,8 @@
           'without-footer': !hasFooter
         }"
         [ngStyle]="{
-          'background-color': bodyColor
+          'background-color': bodyColor,
+          'padding': bodyPadding,
         }"
       >
         <ng-content></ng-content>

--- a/src/components/sq-overlay/sq-overlay.component.scss
+++ b/src/components/sq-overlay/sq-overlay.component.scss
@@ -63,7 +63,6 @@
         }
         .modal-body {
           height: calc(100vh - 112px);
-          padding: 2rem;
           overflow-y: auto;
           overflow-x: hidden;
           &.without-footer {

--- a/src/components/sq-overlay/sq-overlay.component.ts
+++ b/src/components/sq-overlay/sq-overlay.component.ts
@@ -113,7 +113,7 @@ export class SqOverlayComponent implements OnChanges, OnDestroy {
    * The padding applied to the overlay body.
    *
    */
-  @Input() bodyPadding?: string
+  @Input() bodyPadding = '2rem'
 
   /**
    * Emits an event when the overlay is closed.

--- a/src/components/sq-overlay/sq-overlay.component.ts
+++ b/src/components/sq-overlay/sq-overlay.component.ts
@@ -110,6 +110,12 @@ export class SqOverlayComponent implements OnChanges, OnDestroy {
   @Input() backdrop = 'static'
 
   /**
+   * The padding applied to the overlay body.
+   *
+   */
+  @Input() bodyPadding?: string
+
+  /**
    * Emits an event when the overlay is closed.
    *
    */
@@ -298,7 +304,7 @@ export class SqOverlayComponent implements OnChanges, OnDestroy {
     this.finishOpening = false
     this.undoCssWidth()
     overlay?.parentNode?.removeChild(overlay)
-    if (this.modalNumber === 2) { 
+    if (this.modalNumber === 2) {
       backdrop?.removeAttribute('style')
     } else if (this.modalNumber <= 1) {
       backdrop?.parentNode?.removeChild(backdrop)

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squidit/ngx-css",
-  "version": "1.3.77",
+  "version": "1.3.78",
   "peerDependencies": {
     "@angular/common": ">=15.0.0",
     "@angular/cdk": ">=15.0.0",


### PR DESCRIPTION
This pull request enhances the `SqOverlayComponent` by introducing a new `bodyPadding` input property to allow customization of the padding for the overlay body. The changes include updates to both the component's HTML template and TypeScript class.

**Enhancements to `SqOverlayComponent`:**

* [`src/components/sq-overlay/sq-overlay.component.html`](diffhunk://#diff-f34695100489cbe83cf737a1542643c4a84411cdc464d8ca98724786c7427a9aL35-R36): Added support for a `padding` style in the overlay body by binding it to the newly introduced `bodyPadding` property.
* [`src/components/sq-overlay/sq-overlay.component.ts`](diffhunk://#diff-b1c5afc5af11a3ab2b8278604acae46cdbc3b74c088f590a77ffd811ec9de28dR112-R117): Introduced a new `@Input` property, `bodyPadding`, to allow users to specify the padding for the overlay body.