### PR TITLE
fix(forms): correct count display in multi-selection indicator

### DIFF
--- a/src/components/sq-select-multi/sq-select-multi.component.html
+++ b/src/components/sq-select-multi/sq-select-multi.component.html
@@ -76,7 +76,7 @@
           <span class="selected-value">
             {{ value[0]?.label }}
             <span *ngIf="value.length > 1">
-              {{ 'forms.more' | translateInternal | async }} {{ value.length }}
+              {{ 'forms.more' | translateInternal | async }} {{ value.length - 1 }}
             </span>
           </span>
         </div>

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squidit/ngx-css",
-  "version": "1.3.78",
+  "version": "1.3.79",
   "peerDependencies": {
     "@angular/common": ">=15.0.0",
     "@angular/cdk": ">=15.0.0",


### PR DESCRIPTION
This pull request includes a minor fix to the `sq-select-multi.component.html` file. The change ensures that the displayed count of additional selected items is accurate by subtracting 1 from the total length of the `value` array.

* [`src/components/sq-select-multi/sq-select-multi.component.html`](diffhunk://#diff-1226af7bfdaf50695ae2caef2baa0507665601d9a322d239dab7f43397e75972L79-R79): Corrected the displayed count of additional selected items by changing `value.length` to `value.length - 1` in the template.- Added `-1` calculation to show accurate remaining count when multiple items are selected
- Previously showed incorrect value (e.g., displayed "+2" when 2 items were selected)
- Fixes issue where first selected item was counted in addition to remaining count

The change ensures:
- When 2 items are selected → shows "+1" (correct)
- When 3 items are selected → shows "+2" (correct)
- Matches user expectation for multi-selection displays